### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 exports = module.exports = require('./src/device-detector');
-exports.version = require('./package').version;
+exports.version = require('./package.json').version;


### PR DESCRIPTION
Request to explicitly define the .json extension when requiring package.json.

When using device-detector in angular cli it fails with the message below, probably because webpack is not configured to find .json files. The webpack config used by angular cli cannot be modified. 

```
ERROR in ./~/device-detector/index.js
Module not found: Error: Can't resolve './package'
```